### PR TITLE
Add Macchiato theme to theme list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ You can create a pull request or create an issue with your github repository to 
 
 ## [Magnetic Revival](https://github.com/mradziwanowski/magentic-revival-bitwig-theme) by [@mradziwanowski](https://github.com/mradziwanowski)
 <img src="https://github.com/mradziwanowski/magentic-revival-bitwig-theme/raw/master/example.png" alt="Magnetic Revival" width="768"/>
+
+## [Macchiato](https://github.com/lenninst/Macchiato_BitwigTheme.git) by [@lenninst](https://github.com/lenninst)
+<img src="https://raw.githubusercontent.com/lenninst/Macchiato_BitwigTheme/c1dd6d60a30c06d75a235626350155c5ecefb781/img/Bitwig_Macchiato.png" alt="Macchiato" width="768"/>

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ You can create a pull request or create an issue with your github repository to 
 <img src="https://github.com/mradziwanowski/magentic-revival-bitwig-theme/raw/master/example.png" alt="Magnetic Revival" width="768"/>
 
 ## [Macchiato](https://github.com/lenninst/Macchiato_BitwigTheme.git) by [@lenninst](https://github.com/lenninst)
-<img src="https://raw.githubusercontent.com/lenninst/Macchiato_BitwigTheme/c1dd6d60a30c06d75a235626350155c5ecefb781/img/Bitwig_Macchiato.png" alt="Macchiato" width="768"/>
+<img src="https://raw.githubusercontent.com/lenninst/Macchiato_BitwigTheme/main/macchiato.png" alt="Macchiato" width="768"/>


### PR DESCRIPTION
I'd like to contribute my Macchiato theme to the Awesome Bitwig Themes list.

Theme details:
- Name: Macchiato
- Repository: https://github.com/lenninst/Macchiato_BitwigTheme.git
- Description: A Bitwig Studio theme inspired by the Catppuccin Macchiato color palette, offering a balanced and visually pleasing dark theme for music production.

I've added the theme entry to the README.md file following the existing format.

Thank you for considering my contribution!