### PR TITLE
Add Cold Teal + Cold Teal HC themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ You can create a pull request or create an issue with your github repository to 
 ## [Cold Teal](https://github.com/OppliFel/cold-teal-bitwig-theme) by [@OppliFel](https://github.com/OppliFel)
 <!-- RAW: https://raw.githubusercontent.com/OppliFel/cold-teal-bitwig-theme/refs/heads/main/cold-teal.bte -->
 <img src="https://raw.githubusercontent.com/OppliFel/cold-teal-bitwig-theme/main/screenshots/cold-teal.png" alt="Cold Teal" width="768"/>
+
+## [Cold Teal HC](https://github.com/OppliFel/cold-teal-bitwig-theme) by [@OppliFel](https://github.com/OppliFel)
+<!-- RAW: https://raw.githubusercontent.com/OppliFel/cold-teal-bitwig-theme/refs/heads/main/cold-teal-hc.bte -->
+<img src="https://raw.githubusercontent.com/OppliFel/cold-teal-bitwig-theme/main/screenshots/cold-teal-hc.png" alt="Cold Teal HC" width="768"/>

--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ You can create a pull request or create an issue with your github repository to 
 ## [Dracula](https://github.com/sleeplessKomodo/bitwig-dracula-theme) by [@sleeplessKomodo](https://github.com/sleeplessKomodo)
 <!-- RAW: https://raw.githubusercontent.com/sleeplessKomodo/bitwig-dracula-theme/refs/heads/main/dracula.json -->
 <img src="https://raw.githubusercontent.com/sleeplessKomodo/bitwig-dracula-theme/refs/heads/main/images/dracula.png" alt="Dracula" width="768"/>
+
+## [Cold Teal](https://github.com/OppliFel/cold-teal-bitwig-theme) by [@OppliFel](https://github.com/OppliFel)
+<!-- RAW: https://raw.githubusercontent.com/OppliFel/cold-teal-bitwig-theme/refs/heads/main/cold-teal.bte -->
+<img src="https://raw.githubusercontent.com/OppliFel/cold-teal-bitwig-theme/main/screenshots/cold-teal.png" alt="Cold Teal" width="768"/>


### PR DESCRIPTION
Adds **Cold Teal** — a de-oranged, cold two-accent theme for Bitwig (built and verified on 6.0.6): teal `#1bafc0` for everything interactive, a champagne `#ebdcbe` control-center readout (transport + playhead), on subtly cooled neutral greys. Semantic colors (meters, record, modulation, track/clip palette) kept stock on purpose.

Ships in the current `.bte` format, with a legacy `.json` for older editors.

Repo: https://github.com/OppliFel/cold-teal-bitwig-theme